### PR TITLE
Fix Install On Recent Ubuntu Version + Documentation Addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,19 @@
 # xschem-gaw
+
+## Quick Install
+
+To install gaw perform these commands:
+
+```
+bash
+aclocal && automake --add-missing && autoconf
+./configure
+make
+sudo make install
+```
+
+## More Information
+
 gaw3-20200922 fork with patches to improve remote commands sent from xschem to display waveforms.
 Original work from Hervé Quillévéré
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 
 To install gaw perform these commands:
 
-```
-bash
+```bash
 aclocal && automake --add-missing && autoconf
 ./configure
 make

--- a/po/Makefile.in.in
+++ b/po/Makefile.in.in
@@ -8,8 +8,8 @@
 # Please note that the actual code of GNU gettext is covered by the GNU
 # General Public License and is *not* in the public domain.
 #
-# Origin: gettext-0.18
-GETTEXT_MACRO_VERSION = 0.18
+# Origin: gettext-0.19
+GETTEXT_MACRO_VERSION = 0.19
 
 PACKAGE = @PACKAGE@
 VERSION = @VERSION@


### PR DESCRIPTION
There are two main changes here:

1. Update the gettext version number because version 0.18 causes build errors on recent Ubuntu versions

2. Added some quick commands to help with installation. Most notably the aclocal/automake/autoconf which are not obvious