### PR TITLE
Fixed overflowing value for big spice raw files

### DIFF
--- a/lib/spicestream.h
+++ b/lib/spicestream.h
@@ -50,7 +50,7 @@ struct _SpiceStream {
    int need_update;
    /* some more variables for hspice */
    int nsweepparam;
-   int expected_vals;    /* number of float in the data block */
+   long expected_vals;    /* number of float in the data block */
    int read_sweepparam;
    int read_vals;        /* number of float read              */
    int read_tables;

--- a/lib/ss_spice3.c
+++ b/lib/ss_spice3.c
@@ -154,7 +154,7 @@ int sf_rdhdr_s3raw( SpiceStream *ss )
       ss->rdValFunc = sf_getval_s3ascii ;
    }
    ss->nrows = npoints;
-   ss->expected_vals = npoints * ss->ncols ;
+   ss->expected_vals = (long) npoints * ss->ncols ;
    msg_dbg("expecting %d rows %d cols %d values", npoints, ss->ncols, ss->expected_vals);
    msg_dbg("Done with header at offset 0x%lx\n", (long) fdbuf_tello(ss->linebuf) );
    dbuf_clear((DBuf *) ss->linebuf);


### PR DESCRIPTION
Hi,

I was having an issue loading a Spice 3 raw file with 42375 variables and 59807 points. I would get the following when loading the file:
`Empty table in file. Please, respect the file format.`

The file caused the `expected_vals` in `SpiceStream` to overflow. Changing `expected_vals` from int to long, seems to have fixed the issue. 